### PR TITLE
Release v1.2.0

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -3,7 +3,7 @@ tag-template: "v$NEXT_PATCH_VERSION"
 categories:
   - title: "🤖 Dependencies"
     labels:
-      - "dependencies"
+      - "dependency"
   - title: "🐞 Bug Fixes"
     labels:
       - "fix"

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -11,6 +11,6 @@ categories:
       - "bug"
 change-template: "- $TITLE (#$NUMBER)"
 template: |
-  ## 🚀 Features and improvemens
+  ## Features and improvemens
 
   $CHANGES

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -10,7 +10,4 @@ categories:
       - "bugfix"
       - "bug"
 change-template: "- $TITLE (#$NUMBER)"
-template: |
-  ## Features and improvemens
-
-  $CHANGES
+template: "TEST"

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,16 @@
+name-template: "v$NEXT_PATCH_VERSION"
+tag-template: "v$NEXT_PATCH_VERSION"
+categories:
+  - title: "🤖 Dependencies"
+    labels:
+      - "dependencies"
+  - title: "🐞 Bug Fixes"
+    labels:
+      - "fix"
+      - "bugfix"
+      - "bug"
+change-template: "- $TITLE (#$NUMBER)"
+template: |
+  ## 🚀 Features and improvemens
+
+  $CHANGES

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -10,4 +10,7 @@ categories:
       - "bugfix"
       - "bug"
 change-template: "- $TITLE (#$NUMBER)"
-template: "TEST"
+template: |
+  ## 🚀 Features and improvemens
+
+  $CHANGES

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,19 @@
+name: Release Drafter
+
+on:
+  push:
+    # branches to consider in the event; optional, defaults to all
+    branches:
+      - staging
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "master"
+      - uses: release-drafter/release-drafter@v5
+        with:
+          # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
+          # config-name: my-config.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.OAUTH_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -12,8 +12,5 @@ jobs:
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
       - uses: release-drafter/release-drafter@v5
-        with:
-          # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
-          # config-name: my-config.yml
         env:
           GITHUB_TOKEN: ${{ secrets.OAUTH_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -2,6 +2,6 @@
   "name": "nextrelease-test",
   "version": "1.2.0",
   "dependencies": {
-    "fake-dependency": "^11.2.1"
+    "fake-dependency": "^11.2.2"
   }
 }


### PR DESCRIPTION
Not a good example of a release PR because v1.2.0 was first created with next-release then overridden by release drafter. The next release will be a better example.