### PR TITLE
Change release note category order

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,14 +1,14 @@
 name-template: "v$NEXT_PATCH_VERSION"
 tag-template: "v$NEXT_PATCH_VERSION"
 categories:
-  - title: "🤖 Dependencies"
-    labels:
-      - "dependency"
   - title: "🐞 Bug Fixes"
     labels:
       - "fix"
       - "bugfix"
       - "bug"
+  - title: "🤖 Dependencies"
+    labels:
+      - "dependency"
 change-template: "- $TITLE (#$NUMBER)"
 template: |
   ## 🚀 Features and improvemens


### PR DESCRIPTION
Swaps the order of categories so dependency updates are allways last.