### PR TITLE
Release v1.3.0 to master

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -11,6 +11,6 @@ categories:
       - "dependency"
 change-template: "- $TITLE (#$NUMBER)"
 template: |
-  ## 🚀 Features and improvemens
+  ## 🚀 Features and improvements
 
   $CHANGES

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,14 +1,14 @@
 name-template: "v$NEXT_PATCH_VERSION"
 tag-template: "v$NEXT_PATCH_VERSION"
 categories:
-  - title: "🤖 Dependencies"
-    labels:
-      - "dependency"
   - title: "🐞 Bug Fixes"
     labels:
       - "fix"
       - "bugfix"
       - "bug"
+  - title: "🤖 Dependencies"
+    labels:
+      - "dependency"
 change-template: "- $TITLE (#$NUMBER)"
 template: |
   ## 🚀 Features and improvemens

--- a/README.md
+++ b/README.md
@@ -15,3 +15,11 @@ This branch is the working branch. New commits can only be added via PRs. On arb
 ## release-vX.Y.Z
 
 Branches with this naming convention are used to branch a ready state of staging, bump the version number, create a tag and then merge into master.
+
+## Configuration
+
+The current setup uses the following tools:
+
+- [Release Drafter](https://github.com/release-drafter/release-drafter)
+- [GitHub Actions](https://help.github.com/en/actions)
+- [GitHub Releases](https://help.github.com/en/github/administering-a-repository/managing-releases-in-a-repository)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# nextrelease-test 🐠
+# Release management test
 
-Test for [nextrelease.io](https://nextrelease.io) changelog management.
+Test for release and changelog management.
 
-This repository is a dry run with multiple branches, PRs and tags to see if nextrelease can serve our needs.
+This repository is a dry run with multiple branches, PRs and tags to see what configuration can serve our needs.
 
 ## master
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,6 @@
   "name": "nextrelease-test",
   "version": "1.2.0",
   "dependencies": {
-    "fake-dependency": "^11.2.2"
+    "fake-dependency": "^11.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,6 @@
   "name": "nextrelease-test",
   "version": "1.2.0",
   "dependencies": {
-    "fake-dependency": "^11.3.0"
+    "fake-dependency": "^11.3.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nextrelease-test",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "dependencies": {
     "fake-dependency": "^11.3.1"
   }


### PR DESCRIPTION
## Notes

This PR merges release v1.3.0 into master. In a real situation this would be the one checked by the product owner. Basically, the GitHub releases are only for internal use while the master branch is used to roll out builds to production.

## Changelog

Check all changes in this release here: https://github.com/reisbalans/nextrelease-test/releases/tag/v1.3.0