### PR TITLE
Test manual draft version

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,5 +1,5 @@
-name-template: "v$NEXT_PATCH_VERSION"
-tag-template: "v$NEXT_PATCH_VERSION"
+name-template: "v1.4.0"
+tag-template: "v1.4.0"
 categories:
   - title: "🐞 Bug Fixes"
     labels:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nextrelease-test",
-  "version": "1.3.21",
+  "version": "1.4.0",
   "dependencies": {
     "fake-dependency": "^11.3.1"
   }


### PR DESCRIPTION
If this works we can update the version in the local `yarn bump` script and won't need to update it manually in the release draft.