### PR TITLE
Generate unique release branches

### DIFF
--- a/.github/workflows/release-master-pr.yml
+++ b/.github/workflows/release-master-pr.yml
@@ -9,16 +9,16 @@ jobs:
   pull-request:
     runs-on: ubuntu-latest
     steps:
+      - name: Get the version
+        id: get_version
+        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\/v/}
       - name: create-branch
         uses: peterjgrainger/action-create-branch@v2.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          branch: "release-to-master"
+          branch: "master-release-v${{ steps.get_version.outputs.VERSION }}"
       - uses: actions/checkout@v1
-      - name: Get the version
-        id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\/v/}
       - name: Get the latest release notes
         id: get_latest_release_notes
         uses: actions/github-script@0.9.0

--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ This branch is the production environment and should always be deployable.
 
 This branch is the working branch. New commits can only be added via PRs. On arbitrary intervals a release is branched from staging.
 
-### release-to-master
+### master-release-vX.Y.Z
 
-This branch is automatically generated when a release draft is published. It is branched from that release tag and set to be merged into master.
+A branch with this naming pattern is automatically generated when a release draft is published. It is branched from that release tag and set to be merged into master.
 
 ## ⚙️ Configuration
 


### PR DESCRIPTION
Probably master releases were not generated because the `release-to-master` branche was not deleted after a previous release. That meant it was not re-based on the new tag and thus no differences with master were found.

This fix introduces a config change that will generate a branch with a naming pattern that includes the version number. This should prevent the issue in the future.